### PR TITLE
feat: add server-side error handling

### DIFF
--- a/advanced-integration/paypal-api.js
+++ b/advanced-integration/paypal-api.js
@@ -27,8 +27,8 @@ export async function createOrder() {
       ],
     }),
   });
-  const data = await response.json();
-  return data;
+
+  return handleResponse(response);
 }
 
 // capture payment for an order
@@ -42,8 +42,8 @@ export async function capturePayment(orderId) {
       Authorization: `Bearer ${accessToken}`,
     },
   });
-  const data = await response.json();
-  return data;
+
+  return handleResponse(response);
 }
 
 // generate access token
@@ -56,8 +56,8 @@ export async function generateAccessToken() {
       Authorization: `Basic ${auth}`,
     },
   });
-  const data = await response.json();
-  return data.access_token;
+  const jsonData = await handleResponse(response);
+  return jsonData.access_token;
 }
 
 // generate client token
@@ -71,6 +71,16 @@ export async function generateClientToken() {
       "Content-Type": "application/json",
     },
   });
-  const data = await response.json();
-  return data.client_token;
+  console.log('response', response.status)
+  const jsonData = await handleResponse(response);
+  return jsonData.client_token;
+}
+
+async function handleResponse(response) {
+  if (response.status === 200 || response.status === 201) {
+    return response.json();
+  }
+
+  const errorMessage = await response.text();
+  throw new Error(errorMessage);
 }

--- a/advanced-integration/server.js
+++ b/advanced-integration/server.js
@@ -9,21 +9,33 @@ app.use(express.static("public"));
 // render checkout page with client id & unique client token
 app.get("/", async (req, res) => {
   const clientId = process.env.CLIENT_ID;
-  const clientToken = await paypal.generateClientToken();
-  res.render("checkout", { clientId, clientToken });
+  try {
+    const clientToken = await paypal.generateClientToken();
+    res.render("checkout", { clientId, clientToken });
+  } catch (err) {
+    res.status(500).send(err.message);
+  }
 });
 
 // create order
 app.post("/api/orders", async (req, res) => {
-  const order = await paypal.createOrder();
-  res.json(order);
+  try {
+    const order = await paypal.createOrder();
+    res.json(order);
+  } catch (err) {
+    res.status(500).send(err.message);
+  }
 });
 
 // capture payment
 app.post("/api/orders/:orderID/capture", async (req, res) => {
   const { orderID } = req.params;
-  const captureData = await paypal.capturePayment(orderID);
-  res.json(captureData);
+  try {
+    const captureData = await paypal.capturePayment(orderID);
+    res.json(captureData);
+  } catch (err) {
+    res.status(500).send(err.message);
+  }
 });
 
 app.listen(8888);

--- a/standard-integration/paypal-api.js
+++ b/standard-integration/paypal-api.js
@@ -24,8 +24,8 @@ export async function createOrder() {
       ],
     }),
   });
-  const data = await response.json();
-  return data;
+
+  return handleResponse(response);
 }
 
 export async function capturePayment(orderId) {
@@ -38,8 +38,8 @@ export async function capturePayment(orderId) {
       Authorization: `Bearer ${accessToken}`,
     },
   });
-  const data = await response.json();
-  return data;
+
+  return handleResponse(response);
 }
 
 export async function generateAccessToken() {
@@ -51,6 +51,16 @@ export async function generateAccessToken() {
       Authorization: `Basic ${auth}`,
     },
   });
-  const data = await response.json();
-  return data.access_token;
+
+  const jsonData = await handleResponse(response);
+  return jsonData.access_token;
+}
+
+async function handleResponse(response) {
+  if (response.status === 200 || response.status === 201) {
+    return response.json();
+  }
+
+  const errorMessage = await response.text();
+  throw new Error(errorMessage);
 }

--- a/standard-integration/server.js
+++ b/standard-integration/server.js
@@ -7,14 +7,22 @@ const app = express();
 app.use(express.static("public"));
 
 app.post("/api/orders", async (req, res) => {
-  const order = await paypal.createOrder();
-  res.json(order);
+  try {
+    const order = await paypal.createOrder();
+    res.json(order);
+  } catch (err) {
+    res.status(500).send(err.message);
+  }
 });
 
 app.post("/api/orders/:orderID/capture", async (req, res) => {
   const { orderID } = req.params;
-  const captureData = await paypal.capturePayment(orderID);
-  res.json(captureData);
+  try {
+    const captureData = await paypal.capturePayment(orderID);
+    res.json(captureData);
+  } catch (err) {
+    res.status(500).send(err.message);
+  }
 });
 
 app.listen(8888);


### PR DESCRIPTION
This PR adds error handling to the Express routes. I tried to keep the logic simple and just return a 500 status code for any invalid status code returned by the PayPal APIs.

Here are a couple manual tests I did:

1. Invalid CLIENT_ID/APP_SECRET:
<img width="1525" alt="Screen Shot 2022-06-20 at 1 10 42 PM" src="https://user-images.githubusercontent.com/534034/174658348-95a26bb6-2841-474b-9236-4a17a2f6f78e.png">


2. Invalid amount for create order call:

<img width="1523" alt="Screen Shot 2022-06-20 at 1 10 15 PM" src="https://user-images.githubusercontent.com/534034/174658355-6c3bacbb-4740-4bda-977a-5d32365241d6.png">
 