### PR TITLE
Add testing instructions

### DIFF
--- a/advanced-integration/README.md
+++ b/advanced-integration/README.md
@@ -6,3 +6,4 @@
 2. Run `npm install`
 3. Run `npm start`
 4. Open http://localhost:8888
+5. Enter the credit card number provided from one of your [sandbox accounts](https://developer.paypal.com/dashboard/accounts) or [generate a new credit card](https://developer.paypal.com/dashboard/creditCardGenerator)

--- a/standard-integration/README.md
+++ b/standard-integration/README.md
@@ -4,8 +4,10 @@ This folder contains example code for a standard PayPal integration using both t
 
 ## Instructions
 
-1. Replace `test` in `public/index.html` with your app's client-id
-2. Add `CLIENT_ID` and `APP_SECRET` to the `.env` file
-3. Run `npm install`
-4. Run `npm start`
-5. Open http://localhost:8888
+1. [Create an application](https://developer.paypal.com/dashboard/applications/sandbox/create)
+3. Add your app's `CLIENT_ID` and `APP_SECRET` to the `.env` file
+2. Replace `test` in `public/index.html` with your app's client-id
+4. Run `npm install`
+5. Run `npm start`
+6. Open http://localhost:8888
+7. Click "PayPal" and log in with one of your [Sandbox test accounts](https://developer.paypal.com/dashboard/accounts).


### PR DESCRIPTION
I was following the instructions on https://developer.paypal.com/docs/checkout/advanced/integrate but it was not clear to me how to test this application once I left developer.paypal.com and started working in this code base. 

These instructions are publicly available at https://developer.paypal.com/docs/checkout/advanced/integrate/#link-testingpurchases but I thought having them in the readme as well could make it more obvious.