### PR TITLE
chore(standard-integration): update fetch calls to match public docs

### DIFF
--- a/standard-integration/public/index.html
+++ b/standard-integration/public/index.html
@@ -51,7 +51,7 @@
                   orderData,
                   JSON.stringify(orderData, null, 2)
                 );
-                var transaction = orderData.purchase_units[0].payments.captures[0];
+                const transaction = orderData.purchase_units[0].payments.captures[0];
                 alert(
                   "Transaction " +
                     transaction.status +

--- a/standard-integration/public/index.html
+++ b/standard-integration/public/index.html
@@ -13,15 +13,18 @@
         .Buttons({
           // Sets up the transaction when a payment button is clicked
           createOrder: function () {
-            return fetch("/api/orders", {
+            return fetch("/my-server/create-paypal-order", {
               method: "post",
+              headers: {
+                "Content-Type": "application/json",
+              },
               // use the "body" param to optionally pass additional order information
               // like product skus and quantities
               body: JSON.stringify({
                 cart: [
                   {
-                    sku: "<YOUR_PRODUCT_STOCK_KEEPING_UNIT>",
-                    quantity: "<YOUR_PRODUCT_QUANTITY>",
+                    sku: "YOUR_PRODUCT_STOCK_KEEPING_UNIT",
+                    quantity: "YOUR_PRODUCT_QUANTITY",
                   },
                 ],
               }),
@@ -31,8 +34,14 @@
           },
           // Finalize the transaction after payer approval
           onApprove: function (data) {
-            return fetch(`/api/orders/${data.orderID}/capture`, {
+            return fetch("/my-server/capture-paypal-order", {
               method: "post",
+              headers: {
+                "Content-Type": "application/json",
+              },
+              body: JSON.stringify({
+                orderID: data.orderID,
+              }),
             })
               .then((response) => response.json())
               .then((orderData) => {
@@ -42,8 +51,7 @@
                   orderData,
                   JSON.stringify(orderData, null, 2)
                 );
-                var transaction =
-                  orderData.purchase_units[0].payments.captures[0];
+                var transaction = orderData.purchase_units[0].payments.captures[0];
                 alert(
                   "Transaction " +
                     transaction.status +

--- a/standard-integration/server.js
+++ b/standard-integration/server.js
@@ -6,7 +6,10 @@ const app = express();
 
 app.use(express.static("public"));
 
-app.post("/api/orders", async (req, res) => {
+// parse post params sent in body in json format
+app.use(express.json());
+
+app.post("/my-server/create-paypal-order", async (req, res) => {
   try {
     const order = await paypal.createOrder();
     res.json(order);
@@ -15,8 +18,8 @@ app.post("/api/orders", async (req, res) => {
   }
 });
 
-app.post("/api/orders/:orderID/capture", async (req, res) => {
-  const { orderID } = req.params;
+app.post("/my-server/capture-paypal-order", async (req, res) => {
+  const { orderID } = req.body;
   try {
     const captureData = await paypal.capturePayment(orderID);
     res.json(captureData);


### PR DESCRIPTION
This PR makes the following changes to the standard-integration example:
1. Updates the api paths to match the docs(/my-server/create-paypal-order and /my-server/capture-paypal-order)
2. Updates the fetch calls to set the content-type as application/json
3. Adds the built in `express.json()` middleware to parse the post body.