### PR TITLE
Log URL with port on app start

### DIFF
--- a/advanced-integration/server.js
+++ b/advanced-integration/server.js
@@ -39,5 +39,5 @@ app.post("/api/orders/:orderID/capture", async (req, res) => {
 });
 
 app.listen(8888, () => {
-  console.log('App listening at http://localhost:8888/')
+  console.log('App listening at http://localhost:8888/');
 });

--- a/advanced-integration/server.js
+++ b/advanced-integration/server.js
@@ -1,6 +1,7 @@
 import "dotenv/config";
 import express from "express";
 import * as paypal from "./paypal-api.js";
+const {PORT = 8888} = process.env;
 
 const app = express();
 app.set("view engine", "ejs");
@@ -38,6 +39,6 @@ app.post("/api/orders/:orderID/capture", async (req, res) => {
   }
 });
 
-app.listen(8888, () => {
-  console.log('Server listening at http://localhost:8888/');
+app.listen(PORT, () => {
+  console.log(`Server listening at http://localhost:${PORT}/`);
 });

--- a/advanced-integration/server.js
+++ b/advanced-integration/server.js
@@ -38,4 +38,6 @@ app.post("/api/orders/:orderID/capture", async (req, res) => {
   }
 });
 
-app.listen(8888);
+app.listen(8888, () => {
+  console.log('App listening at http://localhost:8888/')
+});

--- a/advanced-integration/server.js
+++ b/advanced-integration/server.js
@@ -39,5 +39,5 @@ app.post("/api/orders/:orderID/capture", async (req, res) => {
 });
 
 app.listen(8888, () => {
-  console.log('App listening at http://localhost:8888/');
+  console.log('Server listening at http://localhost:8888/');
 });

--- a/standard-integration/server.js
+++ b/standard-integration/server.js
@@ -26,5 +26,5 @@ app.post("/api/orders/:orderID/capture", async (req, res) => {
 });
 
 app.listen(8888, () => {
-  console.log("App listening at http://localhost:8888/");
+  console.log("Server listening at http://localhost:8888/");
 });

--- a/standard-integration/server.js
+++ b/standard-integration/server.js
@@ -26,5 +26,5 @@ app.post("/api/orders/:orderID/capture", async (req, res) => {
 });
 
 app.listen(8888, () => {
-  console.log("App listening at http://localhost:8888/")
+  console.log("App listening at http://localhost:8888/");
 });

--- a/standard-integration/server.js
+++ b/standard-integration/server.js
@@ -1,6 +1,7 @@
 import "dotenv/config"; // loads variables from .env file
 import express from "express";
 import * as paypal from "./paypal-api.js";
+const {PORT = 8888} = process.env;
 
 const app = express();
 
@@ -25,6 +26,6 @@ app.post("/api/orders/:orderID/capture", async (req, res) => {
   }
 });
 
-app.listen(8888, () => {
-  console.log("Server listening at http://localhost:8888/");
+app.listen(PORT, () => {
+  console.log(`Server listening at http://localhost:${PORT}/`);
 });

--- a/standard-integration/server.js
+++ b/standard-integration/server.js
@@ -25,4 +25,6 @@ app.post("/api/orders/:orderID/capture", async (req, res) => {
   }
 });
 
-app.listen(8888);
+app.listen(8888, () => {
+  console.log("App listening at http://localhost:8888/")
+});


### PR DESCRIPTION
Starting the application now displays the URL in a terminal:

```
$ npm start

> @paypalcorp/standard-integration@1.0.0 start /docs-examples/standard-integration
> node server.js

Server listening at http://localhost:8888/
```