### PR TITLE
chore: use es6 syntax to match public docs

### DIFF
--- a/standard-integration/public/index.html
+++ b/standard-integration/public/index.html
@@ -12,9 +12,9 @@
       paypal
         .Buttons({
           // Sets up the transaction when a payment button is clicked
-          createOrder: function () {
+          createOrder() {
             return fetch("/my-server/create-paypal-order", {
-              method: "post",
+              method: "POST",
               headers: {
                 "Content-Type": "application/json",
               },
@@ -33,9 +33,9 @@
               .then((order) => order.id);
           },
           // Finalize the transaction after payer approval
-          onApprove: function (data) {
+          onApprove(data) {
             return fetch("/my-server/capture-paypal-order", {
-              method: "post",
+              method: "POST",
               headers: {
                 "Content-Type": "application/json",
               },
@@ -52,13 +52,7 @@
                   JSON.stringify(orderData, null, 2)
                 );
                 const transaction = orderData.purchase_units[0].payments.captures[0];
-                alert(
-                  "Transaction " +
-                    transaction.status +
-                    ": " +
-                    transaction.id +
-                    "\n\nSee console for all available details"
-                );
+                alert(`Transaction ${transaction.status}: ${transaction.id}\n\nSee console for all available details`);
                 // When ready to go live, remove the alert and show a success message within this page. For example:
                 // var element = document.getElementById('paypal-button-container');
                 // element.innerHTML = '<h3>Thank you for your payment!</h3>';


### PR DESCRIPTION
This PR updates the [Standard Integration guide](https://developer.paypal.com/docs/checkout/standard/integrate/) code snippets to match whats on developer.paypal.com.

There are 3 changes:
1. Prefer [method definitions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Method_definitions) for a shorter syntax
2. Prefer [template strings](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals) for concatenating strings with variables.
3. Use uppercase POST for fetch() calls to be spec compliant: https://fetch.spec.whatwg.org/#methods

Note that the Advanced Integration guide should be updated to follow these same standards.
