### PR TITLE
chore(docs): fix path to index.html in readme

### DIFF
--- a/standard-integration/README.md
+++ b/standard-integration/README.md
@@ -6,7 +6,7 @@ This folder contains example code for a standard PayPal integration using both t
 
 1. [Create an application](https://developer.paypal.com/dashboard/applications/sandbox/create)
 3. Rename `.env.example` to `.env` and update `PAYPAL_CLIENT_ID` and `PAYPAL_CLIENT_SECRET`
-2. Replace `test` in `public/index.html` with your app's client-id
+2. Replace `test` in `index.html` with your app's client-id
 4. Run `npm install`
 5. Run `npm start`
 6. Open http://localhost:8888


### PR DESCRIPTION
I forgot to update the readme in the previous PR to use the new index.html path.