### PR TITLE
Use paypal-js for loading the JS SDK

### DIFF
--- a/standard-integration/client/app.js
+++ b/standard-integration/client/app.js
@@ -1,9 +1,10 @@
 import { loadScript } from "https://www.paypalobjects.com/paypal-js/esm/paypal.min.js";
 
 loadScript({
-  // replace the "test" clientId value with your own
+  components: ["buttons", "messages", "hosted-fields"],
   clientId: "test",
   currency: "USD",
+  enableFunding: ["venmo"]
 }).then((paypal) => {
   paypal
     .Buttons({

--- a/standard-integration/client/app.js
+++ b/standard-integration/client/app.js
@@ -1,91 +1,103 @@
-window.paypal
-  .Buttons({
-    async createOrder() {
-      try {
-        const response = await fetch("/api/orders", {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          // use the "body" param to optionally pass additional order information
-          // like product ids and quantities
-          body: JSON.stringify({
-            cart: [
-              {
-                id: "YOUR_PRODUCT_ID",
-                quantity: "YOUR_PRODUCT_QUANTITY",
-              },
-            ],
-          }),
-        });
+import { loadScript } from "https://www.paypalobjects.com/paypal-js/esm/paypal.min.js";
 
-        const orderData = await response.json();
+loadScript({
+  // replace the "test" clientId value with your own
+  clientId: "test",
+  currency: "USD",
+}).then((paypal) => {
+  paypal
+    .Buttons({
+      async createOrder() {
+        try {
+          const response = await fetch("/api/orders", {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            // use the "body" param to optionally pass additional order information
+            // like product ids and quantities
+            body: JSON.stringify({
+              cart: [
+                {
+                  id: "YOUR_PRODUCT_ID",
+                  quantity: "YOUR_PRODUCT_QUANTITY",
+                },
+              ],
+            }),
+          });
 
-        if (orderData.id) {
-          return orderData.id;
-        } else {
-          const errorDetail = orderData?.details?.[0];
-          const errorMessage = errorDetail
-            ? `${errorDetail.issue} ${errorDetail.description} (${orderData.debug_id})`
-            : JSON.stringify(orderData);
+          const orderData = await response.json();
 
-          throw new Error(errorMessage);
-        }
-      } catch (error) {
-        console.error(error);
-        resultMessage(`Could not initiate PayPal Checkout...<br><br>${error}`);
-      }
-    },
-    async onApprove(data, actions) {
-      try {
-        const response = await fetch(`/api/orders/${data.orderID}/capture`, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-        });
+          if (orderData.id) {
+            return orderData.id;
+          } else {
+            const errorDetail = orderData?.details?.[0];
+            const errorMessage = errorDetail
+              ? `${errorDetail.issue} ${errorDetail.description} (${orderData.debug_id})`
+              : JSON.stringify(orderData);
 
-        const orderData = await response.json();
-        // Three cases to handle:
-        //   (1) Recoverable INSTRUMENT_DECLINED -> call actions.restart()
-        //   (2) Other non-recoverable errors -> Show a failure message
-        //   (3) Successful transaction -> Show confirmation or thank you message
-
-        const errorDetail = orderData?.details?.[0];
-
-        if (errorDetail?.issue === "INSTRUMENT_DECLINED") {
-          // (1) Recoverable INSTRUMENT_DECLINED -> call actions.restart()
-          // recoverable state, per https://developer.paypal.com/docs/checkout/standard/customize/handle-funding-failures/
-          return actions.restart();
-        } else if (errorDetail) {
-          // (2) Other non-recoverable errors -> Show a failure message
-          throw new Error(`${errorDetail.description} (${orderData.debug_id})`);
-        } else if (!orderData.purchase_units) {
-          throw new Error(JSON.stringify(orderData));
-        } else {
-          // (3) Successful transaction -> Show confirmation or thank you message
-          // Or go to another URL:  actions.redirect('thank_you.html');
-          const transaction =
-            orderData?.purchase_units?.[0]?.payments?.captures?.[0] ||
-            orderData?.purchase_units?.[0]?.payments?.authorizations?.[0];
+            throw new Error(errorMessage);
+          }
+        } catch (error) {
+          console.error(error);
           resultMessage(
-            `Transaction ${transaction.status}: ${transaction.id}<br><br>See console for all available details`,
-          );
-          console.log(
-            "Capture result",
-            orderData,
-            JSON.stringify(orderData, null, 2),
+            `Could not initiate PayPal Checkout...<br><br>${error}`,
           );
         }
-      } catch (error) {
-        console.error(error);
-        resultMessage(
-          `Sorry, your transaction could not be processed...<br><br>${error}`,
-        );
-      }
-    },
-  })
-  .render("#paypal-button-container");
+      },
+      async onApprove(data, actions) {
+        try {
+          const response = await fetch(`/api/orders/${data.orderID}/capture`, {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+          });
+
+          const orderData = await response.json();
+          // Three cases to handle:
+          //   (1) Recoverable INSTRUMENT_DECLINED -> call actions.restart()
+          //   (2) Other non-recoverable errors -> Show a failure message
+          //   (3) Successful transaction -> Show confirmation or thank you message
+
+          const errorDetail = orderData?.details?.[0];
+
+          if (errorDetail?.issue === "INSTRUMENT_DECLINED") {
+            // (1) Recoverable INSTRUMENT_DECLINED -> call actions.restart()
+            // recoverable state, per https://developer.paypal.com/docs/checkout/standard/customize/handle-funding-failures/
+            return actions.restart();
+          } else if (errorDetail) {
+            // (2) Other non-recoverable errors -> Show a failure message
+            throw new Error(
+              `${errorDetail.description} (${orderData.debug_id})`,
+            );
+          } else if (!orderData.purchase_units) {
+            throw new Error(JSON.stringify(orderData));
+          } else {
+            // (3) Successful transaction -> Show confirmation or thank you message
+            // Or go to another URL:  actions.redirect('thank_you.html');
+            const transaction =
+              orderData?.purchase_units?.[0]?.payments?.captures?.[0] ||
+              orderData?.purchase_units?.[0]?.payments?.authorizations?.[0];
+            resultMessage(
+              `Transaction ${transaction.status}: ${transaction.id}<br><br>See console for all available details`,
+            );
+            console.log(
+              "Capture result",
+              orderData,
+              JSON.stringify(orderData, null, 2),
+            );
+          }
+        } catch (error) {
+          console.error(error);
+          resultMessage(
+            `Sorry, your transaction could not be processed...<br><br>${error}`,
+          );
+        }
+      },
+    })
+    .render("#paypal-button-container");
+});
 
 // Example function to show a result to the user. Your site's UI library can be used instead.
 function resultMessage(message) {

--- a/standard-integration/client/checkout.html
+++ b/standard-integration/client/checkout.html
@@ -4,12 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>PayPal JS SDK Standard Integration</title>
+    <script type="module" src="app.js" defer></script>
   </head>
   <body>
     <div id="paypal-button-container"></div>
     <p id="result-message"></p>
-    <!-- Replace the "test" client-id value with your client-id -->
-    <script src="https://www.paypal.com/sdk/js?client-id=test&currency=USD"></script>
-    <script src="app.js"></script>
   </body>
 </html>


### PR DESCRIPTION
_Looking for feedback and consensus before merging._

## Problem

The PayPal JS SDK script is an API that returns JavaScript. It takes in query string parameters as input and uses those settings to return a JavaScript payload that's customized for the merchant. 

```html
 <!-- Use the query string for passing in settings -->
 <script src="https://www.paypal.com/sdk/js?client-id=test&components=buttons,messages,hosted-fields&currency=USD&enable-funding=venmo"></script>
```

Setting these query string parameters in HTML code using a `<script>` tag is difficult for developers. There are two possible solutions to make the HTML dynamic:
1. Server-side rendering using a templating language like EJS
2. Client-side script loading with appending a `<script>` tag to the DOM once the query string inputs are known.

Number 1 is currently taught in the Advanced Integration Guide and adds additional complexity. Number 2 works well but requires merchant developers to roll their own solution for dynamic script loading. It does require the merchant to think about script loading order too. The JS SDK script has to finish loading before any components can be used (ex: `window.paypal.Buttons()`). Also no JavaScript developer likes dealing with our kebab-case parameters.

## Solution

Let's have [paypal-js](https://github.com/paypal/paypal-js) be the recommended way for merchant developers to load the JS SDK script. The paypal-js script loader can be used in two ways:
1. Reference it from the https://www.paypalobjects.com CDN and import the `loadScript` function using [JavaScript Module syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules).
2. Install it from npm as a dependency for merchants that have their own JavaScript asset pipeline solution with webpack/esbuild/rollup.

The paypal-js library also supports passing in query string parameters in camelCase which is what JavaScript developers prefer.

Here's a code example of the new approach:

The HTML code does need to use the `type=module` setting on the script tag to support the `import` syntax.
```html  
<script type="module" src="app.js" defer></script>
```

```js
import { loadScript } from "https://www.paypalobjects.com/paypal-js/esm/paypal.min.js";

loadScript({
  clientId: "test",
  currency: "USD",
}).then((paypal) => {
  paypal.Buttons().render('body');
});
```

## Risks

It seems like every modern browser supports JavaScript modules but we should do more research to confirm. This will not work in IE11 but no one should really care about that anymore. If browser support is a major concern we can update our docs to teach two different options with paypal-js:

1. JavaScript Modules for the cool kids as described above.
2. Using the `window.paypalLoadScript()` option which does not use ES Modules:
```html
<!doctype html>
<html lang="en">
    <head>
        <script src="https://www.paypalobjects.com/paypal-js/iife/paypal.min.js"></script>
    </head>
    <body>
        <div id="paypal-buttons"></div>
        <script>
            window.paypalLoadScript({ clientId: "test" }).then((paypal) => {
                paypal.Buttons().render("#paypal-buttons");
            });
        </script>
    </body>
</html>
```