### PR TITLE
fix one click payment popup issue

### DIFF
--- a/save-payment-method/server/views/checkout.ejs
+++ b/save-payment-method/server/views/checkout.ejs
@@ -9,7 +9,7 @@
     <div id="paypal-button-container"></div>
     <p id="result-message"></p>
     <script
-      src="https://www.paypal.com/sdk/js?client-id=<%= clientId %>&vault=true"
+      src="https://www.paypal.com/sdk/js?client-id=<%= clientId %>"
       data-user-id-token="<%= userIdToken %>"
     ></script>
     <script src="app.js"></script>


### PR DESCRIPTION
This PR fixes an issue where the return buyer experience opened a pop up and prompted a buyer login. The `vault=true` query parameter was incorrectly added in a previous PR comment (see https://github.com/paypal-examples/docs-examples/pull/99#discussion_r1381716472)

<details>
<summary>See Demo 🎥 </summary>


https://github.com/paypal-examples/docs-examples/assets/3824954/2f7183eb-d0d0-411b-974a-bf095ff755dc



</details>