### PR TITLE
fix main lint failure

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: 👕 Lint code with ESLint
         run: >
-          find . -name package.json -maxdepth 2 -type f | while read -r file; do
+          find . -name package.json -maxdepth 3 -type f | while read -r file; do
             directory=$(dirname "$file")
             cd "$directory" && npm run lint && cd -
           done

--- a/advanced-integration/v1/package.json
+++ b/advanced-integration/v1/package.json
@@ -9,7 +9,7 @@
     "start": "nodemon server/server.js",
     "format": "npx prettier --write **/*.{js,md}",
     "format:check": "npx prettier --check **/*.{js,md}",
-    "lint": "npx eslint server/*.js --env=node && npx eslint client/*.js --env=browser"
+    "lint": "npx eslint server/*.js client/*.js --no-config-lookup"
   },
   "license": "Apache-2.0",
   "dependencies": {

--- a/advanced-integration/v2/package.json
+++ b/advanced-integration/v2/package.json
@@ -9,7 +9,7 @@
     "start": "nodemon server/server.js",
     "format": "npx prettier --write **/*.{js,md}",
     "format:check": "npx prettier --check **/*.{js,md}",
-    "lint": "npx eslint server/*.js --env=node && npx eslint client/*.js --env=browser"
+    "lint": "npx eslint server/*.js client/*.js --no-config-lookup"
   },
   "license": "Apache-2.0",
   "dependencies": {

--- a/save-payment-method/package.json
+++ b/save-payment-method/package.json
@@ -9,7 +9,7 @@
     "start": "nodemon server/server.js",
     "format": "npx prettier --write **/*.{js,md}",
     "format:check": "npx prettier --check **/*.{js,md}",
-    "lint": "npx eslint server/*.js --env=node && npx eslint client/*.js --env=browser"
+    "lint": "npx eslint server/*.js client/*.js --no-config-lookup"
   },
   "license": "Apache-2.0",
   "dependencies": {

--- a/standard-integration/package.json
+++ b/standard-integration/package.json
@@ -9,7 +9,7 @@
     "start": "nodemon server/server.js",
     "format": "npx prettier --write **/*.{js,md}",
     "format:check": "npx prettier --check **/*.{js,md}",
-    "lint": "npx eslint server/*.js --env=node && npx eslint client/*.js --env=browser"
+    "lint": "npx eslint server/*.js client/*.js --no-config-lookup"
   },
   "license": "Apache-2.0",
   "dependencies": {


### PR DESCRIPTION
This PR fixes a [lint failure](https://github.com/paypal-examples/docs-examples/actions/runs/8653281615/job/23728105725) on the `main` branch.

`npx eslint` now uses `9.0.0`, which deprecated the `--env` argument unless using the legacy `eslintrc` mode: 

- https://eslint.org/docs/latest/use/command-line-interface#--env
- https://eslint.org/docs/latest/use/migrate-to-9.0.0#-new-default-config-format-eslintconfigjs

I added `--no-config-lookup` to address the lookup error:

```
$ npx eslint

Oops! Something went wrong! :(

ESLint: 9.0.0

Error: Could not find config file.
    at locateConfigFileToUse (node_modules/eslint/lib/eslint/eslint.js:349:21)
```

I also increased the `find -maxdepth` value to include `advanced-integration/v1` and `advanced-integration/v1`