### PR TITLE
Bump SDK version to 0.6.0; Resolve name changes related to bump

### DIFF
--- a/advanced-integration/v2/server/dotnet/PayPalAdvancedIntegration.csproj
+++ b/advanced-integration/v2/server/dotnet/PayPalAdvancedIntegration.csproj
@@ -7,6 +7,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.9" />
-    <PackageReference Include="PayPalServerSDK" Version="0.5.3" />
+    <PackageReference Include="PayPalServerSDK" Version="0.6.0" />
   </ItemGroup>
 </Project>

--- a/advanced-integration/v2/server/dotnet/Server.cs
+++ b/advanced-integration/v2/server/dotnet/Server.cs
@@ -7,11 +7,11 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using PaypalServerSDK.Standard;
-using PaypalServerSDK.Standard.Authentication;
-using PaypalServerSDK.Standard.Controllers;
-using PaypalServerSDK.Standard.Http.Response;
-using PaypalServerSDK.Standard.Models;
+using PaypalServerSdk.Standard;
+using PaypalServerSdk.Standard.Authentication;
+using PaypalServerSdk.Standard.Controllers;
+using PaypalServerSdk.Standard.Http.Response;
+using PaypalServerSdk.Standard.Models;
 using IConfiguration = Microsoft.Extensions.Configuration.IConfiguration;
 
 namespace PayPalAdvancedIntegration;
@@ -79,8 +79,8 @@ public class CheckoutController : Controller
         _logger = logger;
 
         // Initialize the PayPal SDK client
-        PaypalServerSDKClient client = new PaypalServerSDKClient.Builder()
-            .Environment(PaypalServerSDK.Standard.Environment.Sandbox)
+        PaypalServerSdkClient client = new PaypalServerSdkClient.Builder()
+            .Environment(PaypalServerSdk.Standard.Environment.Sandbox)
             .ClientCredentialsAuth(
                 new ClientCredentialsAuthModel.Builder(_paypalClientId, _paypalClientSecret).Build()
             )

--- a/advanced-integration/v2/server/java/pom.xml
+++ b/advanced-integration/v2/server/java/pom.xml
@@ -48,7 +48,7 @@
 				paypal-server-sdk
 			</artifactId>
 			<version>
-				0.5.1
+				0.6.0
 			</version>
 		</dependency>
 	</dependencies>

--- a/advanced-integration/v2/server/java/src/main/java/com/paypal/sample/SampleAppApplication.java
+++ b/advanced-integration/v2/server/java/src/main/java/com/paypal/sample/SampleAppApplication.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.client.RestTemplate;
 
 import com.paypal.sdk.Environment;
-import com.paypal.sdk.PaypalServerSDKClient;
+import com.paypal.sdk.PaypalServerSdkClient;
 import com.paypal.sdk.authentication.ClientCredentialsAuthModel;
 import com.paypal.sdk.controllers.OrdersController;
 import com.paypal.sdk.exceptions.ApiException;
@@ -53,8 +53,8 @@ public class SampleAppApplication {
 	}
 
 	@Bean
-    public PaypalServerSDKClient paypalClient() {
-        return new PaypalServerSDKClient.Builder()
+    public PaypalServerSdkClient paypalClient() {
+        return new PaypalServerSdkClient.Builder()
                 .loggingConfig(builder -> builder
                         .level(Level.DEBUG)
                         .requestConfig(logConfigBuilder -> logConfigBuilder.body(true))
@@ -75,9 +75,9 @@ public class SampleAppApplication {
 	public class CheckoutController {
 
 		private final ObjectMapper objectMapper;
-		private final PaypalServerSDKClient client;
+		private final PaypalServerSdkClient client;
 
-		public CheckoutController(ObjectMapper objectMapper, PaypalServerSDKClient client) {
+		public CheckoutController(ObjectMapper objectMapper, PaypalServerSdkClient client) {
 			this.objectMapper = objectMapper;
 			this.client = client;
 		}

--- a/advanced-integration/v2/server/node/package.json
+++ b/advanced-integration/v2/server/node/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "@paypal/paypal-server-sdk": "^0.5.1",
+    "@paypal/paypal-server-sdk": "^0.6.0",
     "body-parser": "^1.20.3",
     "dotenv": "^16.3.1",
     "express": "^4.18.2"

--- a/advanced-integration/v2/server/node/server.js
+++ b/advanced-integration/v2/server/node/server.js
@@ -42,7 +42,7 @@ const ordersController = new OrdersController(client);
 const createOrder = async (cart) => {
   const collect = {
     body: {
-      intent: CheckoutPaymentIntent.CAPTURE,
+      intent: CheckoutPaymentIntent.Capture,
       purchaseUnits: [
         {
           amount: {
@@ -56,8 +56,9 @@ const createOrder = async (cart) => {
   };
 
   try {
-    const { body, ...httpResponse } =
-      await ordersController.ordersCreate(collect);
+    const { body, ...httpResponse } = await ordersController.ordersCreate(
+      collect
+    );
     // Get more response info...
     // const { statusCode, headers } = httpResponse;
     return {
@@ -83,8 +84,9 @@ const captureOrder = async (orderID) => {
   };
 
   try {
-    const { body, ...httpResponse } =
-      await ordersController.ordersCapture(collect);
+    const { body, ...httpResponse } = await ordersController.ordersCapture(
+      collect
+    );
     // Get more response info...
     // const { statusCode, headers } = httpResponse;
     return {

--- a/advanced-integration/v2/server/php/composer.json
+++ b/advanced-integration/v2/server/php/composer.json
@@ -4,12 +4,15 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "paypal/paypal-server-sdk": "0.5.1"
+        "paypal/paypal-server-sdk": "0.6.0"
     },
     "require-dev": {
     },
     "scripts": {
-        "start": "php -S localhost:8080 -t src"
+        "start": [
+            "Composer\\Config::disableProcessTimeout",
+            "php -S localhost:8080 -t src"
+    ]
     },
     "config": {
     }

--- a/advanced-integration/v2/server/php/composer.lock
+++ b/advanced-integration/v2/server/php/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d4a57a266f3f33beef57b02efc8cfaac",
+    "content-hash": "f2e528a550aa0e8926b330dcdcfc67dc",
     "packages": [
         {
             "name": "apimatic/core",
@@ -224,16 +224,16 @@
         },
         {
             "name": "paypal/paypal-server-sdk",
-            "version": "0.5.1",
+            "version": "0.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/paypal/PayPal-PHP-Server-SDK.git",
-                "reference": "09148245f72f9dc2f6c8363b6206eac5effefa77"
+                "reference": "7d69e118998fdf2ae2cf234f1bd49f4248782380"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paypal/PayPal-PHP-Server-SDK/zipball/09148245f72f9dc2f6c8363b6206eac5effefa77",
-                "reference": "09148245f72f9dc2f6c8363b6206eac5effefa77",
+                "url": "https://api.github.com/repos/paypal/PayPal-PHP-Server-SDK/zipball/7d69e118998fdf2ae2cf234f1bd49f4248782380",
+                "reference": "7d69e118998fdf2ae2cf234f1bd49f4248782380",
                 "shasum": ""
             },
             "require": {
@@ -250,7 +250,7 @@
             "type": "library",
             "autoload": {
                 "psr-4": {
-                    "PaypalServerSDKLib\\": "src/"
+                    "PaypalServerSdkLib\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -261,9 +261,9 @@
             "homepage": "https://github.com/paypal/PayPal-PHP-Server-SDK",
             "support": {
                 "issues": "https://github.com/paypal/PayPal-PHP-Server-SDK/issues",
-                "source": "https://github.com/paypal/PayPal-PHP-Server-SDK/tree/0.5.1"
+                "source": "https://github.com/paypal/PayPal-PHP-Server-SDK/tree/0.6.0"
             },
-            "time": "2024-09-10T15:31:38+00:00"
+            "time": "2024-10-18T19:06:27+00:00"
         },
         {
             "name": "php-jsonpointer/php-jsonpointer",

--- a/advanced-integration/v2/server/php/src/index.php
+++ b/advanced-integration/v2/server/php/src/index.php
@@ -1,18 +1,18 @@
 <?php
 require __DIR__ . '/../vendor/autoload.php';
 
-use PaypalServerSDKLib\Authentication\ClientCredentialsAuthCredentialsBuilder;
-use PaypalServerSDKLib\Environment;
-use PaypalServerSDKLib\PaypalServerSDKClientBuilder;
-use PaypalServerSDKLib\Models\Builders\OrderRequestBuilder;
-use PaypalServerSDKLib\Models\CheckoutPaymentIntent;
-use PaypalServerSDKLib\Models\Builders\PurchaseUnitRequestBuilder;
-use PaypalServerSDKLib\Models\Builders\AmountWithBreakdownBuilder;
+use PaypalServerSdkLib\Authentication\ClientCredentialsAuthCredentialsBuilder;
+use PaypalServerSdkLib\Environment;
+use PaypalServerSdkLib\PaypalServerSdkClientBuilder;
+use PaypalServerSdkLib\Models\Builders\OrderRequestBuilder;
+use PaypalServerSdkLib\Models\CheckoutPaymentIntent;
+use PaypalServerSdkLib\Models\Builders\PurchaseUnitRequestBuilder;
+use PaypalServerSdkLib\Models\Builders\AmountWithBreakdownBuilder;
 
 $PAYPAL_CLIENT_ID = getenv('PAYPAL_CLIENT_ID');
 $PAYPAL_CLIENT_SECRET = getenv('PAYPAL_CLIENT_SECRET');
 
-$client = PaypalServerSDKClientBuilder::init()
+$client = PaypalServerSdkClientBuilder::init()
     ->clientCredentialsAuthCredentials(
         ClientCredentialsAuthCredentialsBuilder::init(
             $PAYPAL_CLIENT_ID,

--- a/advanced-integration/v2/server/python/requirements.txt
+++ b/advanced-integration/v2/server/python/requirements.txt
@@ -1,2 +1,2 @@
 Flask==3.0.3
-paypal-server-sdk==0.5.2
+paypal-server-sdk==0.6.0

--- a/advanced-integration/v2/server/python/server.py
+++ b/advanced-integration/v2/server/python/server.py
@@ -5,7 +5,7 @@ from flask import Flask, request
 from paypalserversdk.http.auth.o_auth_2 import ClientCredentialsAuthCredentials
 from paypalserversdk.logging.configuration.api_logging_configuration import LoggingConfiguration, \
     RequestLoggingConfiguration, ResponseLoggingConfiguration
-from paypalserversdk.paypalserversdk_client import PaypalserversdkClient
+from paypalserversdk.paypal_serversdk_client import PaypalServersdkClient
 from paypalserversdk.controllers.orders_controller import OrdersController
 from paypalserversdk.models.amount_with_breakdown import AmountWithBreakdown
 from paypalserversdk.models.checkout_payment_intent import CheckoutPaymentIntent
@@ -15,7 +15,7 @@ from paypalserversdk.api_helper import ApiHelper
 
 app = Flask(__name__)
 
-paypal_client: PaypalserversdkClient = PaypalserversdkClient(
+paypal_client: PaypalServersdkClient = PaypalServersdkClient(
     client_credentials_auth_credentials=ClientCredentialsAuthCredentials(
         o_auth_client_id=os.getenv('PAYPAL_CLIENT_ID'),
         o_auth_client_secret=os.getenv('PAYPAL_CLIENT_SECRET')

--- a/advanced-integration/v2/server/ruby/Gemfile
+++ b/advanced-integration/v2/server/ruby/Gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "paypal-server-sdk", "~> 0.5.2"
+gem "paypal-server-sdk", "~> 0.6.0"
 gem "puma", "~> 6.4"
 gem "rackup", "~> 2.1"
 gem "sinatra", "~> 4.0"

--- a/standard-integration/server/dotnet/PayPalStandardIntegration.csproj
+++ b/standard-integration/server/dotnet/PayPalStandardIntegration.csproj
@@ -7,6 +7,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.9" />
-    <PackageReference Include="PayPalServerSDK" Version="0.5.3" />
+    <PackageReference Include="PayPalServerSDK" Version="0.6.0" />
   </ItemGroup>
 </Project>

--- a/standard-integration/server/dotnet/Server.cs
+++ b/standard-integration/server/dotnet/Server.cs
@@ -7,11 +7,11 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using PaypalServerSDK.Standard;
-using PaypalServerSDK.Standard.Authentication;
-using PaypalServerSDK.Standard.Controllers;
-using PaypalServerSDK.Standard.Http.Response;
-using PaypalServerSDK.Standard.Models;
+using PaypalServerSdk.Standard;
+using PaypalServerSdk.Standard.Authentication;
+using PaypalServerSdk.Standard.Controllers;
+using PaypalServerSdk.Standard.Http.Response;
+using PaypalServerSdk.Standard.Models;
 using IConfiguration = Microsoft.Extensions.Configuration.IConfiguration;
 
 namespace PayPalAdvancedIntegration;
@@ -79,8 +79,8 @@ public class CheckoutController : Controller
         _logger = logger;
 
         // Initialize the PayPal SDK client
-        PaypalServerSDKClient client = new PaypalServerSDKClient.Builder()
-            .Environment(PaypalServerSDK.Standard.Environment.Sandbox)
+        PaypalServerSdkClient client = new PaypalServerSdkClient.Builder()
+            .Environment(PaypalServerSdk.Standard.Environment.Sandbox)
             .ClientCredentialsAuth(
                 new ClientCredentialsAuthModel.Builder(_paypalClientId, _paypalClientSecret).Build()
             )

--- a/standard-integration/server/java/pom.xml
+++ b/standard-integration/server/java/pom.xml
@@ -46,7 +46,7 @@
 				paypal-server-sdk
 			</artifactId>
 			<version>
-				0.5.1
+				0.6.0
 			</version>
 		</dependency>
 	</dependencies>

--- a/standard-integration/server/java/src/main/java/com/paypal/sample/SampleAppApplication.java
+++ b/standard-integration/server/java/src/main/java/com/paypal/sample/SampleAppApplication.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.client.RestTemplate;
 
 import com.paypal.sdk.Environment;
-import com.paypal.sdk.PaypalServerSDKClient;
+import com.paypal.sdk.PaypalServerSdkClient;
 import com.paypal.sdk.authentication.ClientCredentialsAuthModel;
 import com.paypal.sdk.controllers.OrdersController;
 import com.paypal.sdk.exceptions.ApiException;
@@ -53,8 +53,8 @@ public class SampleAppApplication {
 	}
 
 	@Bean
-    public PaypalServerSDKClient paypalClient() {
-        return new PaypalServerSDKClient.Builder()
+    public PaypalServerSdkClient paypalClient() {
+        return new PaypalServerSdkClient.Builder()
                 .loggingConfig(builder -> builder
                         .level(Level.DEBUG)
                         .requestConfig(logConfigBuilder -> logConfigBuilder.body(true))
@@ -75,9 +75,9 @@ public class SampleAppApplication {
 	public class CheckoutController {
 
 		private final ObjectMapper objectMapper;
-		private final PaypalServerSDKClient client;
+		private final PaypalServerSdkClient client;
 
-		public CheckoutController(ObjectMapper objectMapper, PaypalServerSDKClient client) {
+		public CheckoutController(ObjectMapper objectMapper, PaypalServerSdkClient client) {
 			this.objectMapper = objectMapper;
 			this.client = client;
 		}

--- a/standard-integration/server/node/package.json
+++ b/standard-integration/server/node/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "@paypal/paypal-server-sdk": "^0.5.1",
+    "@paypal/paypal-server-sdk": "^0.6.0",
     "body-parser": "^1.20.3",
     "dotenv": "^16.3.1",
     "express": "^4.18.2"

--- a/standard-integration/server/node/server.js
+++ b/standard-integration/server/node/server.js
@@ -42,7 +42,7 @@ const ordersController = new OrdersController(client);
 const createOrder = async (cart) => {
   const collect = {
     body: {
-      intent: CheckoutPaymentIntent.CAPTURE,
+      intent: CheckoutPaymentIntent.Capture,
       purchaseUnits: [
         {
           amount: {
@@ -56,8 +56,9 @@ const createOrder = async (cart) => {
   };
 
   try {
-    const { body, ...httpResponse } =
-      await ordersController.ordersCreate(collect);
+    const { body, ...httpResponse } = await ordersController.ordersCreate(
+      collect
+    );
     // Get more response info...
     // const { statusCode, headers } = httpResponse;
     return {
@@ -83,8 +84,9 @@ const captureOrder = async (orderID) => {
   };
 
   try {
-    const { body, ...httpResponse } =
-      await ordersController.ordersCapture(collect);
+    const { body, ...httpResponse } = await ordersController.ordersCapture(
+      collect
+    );
     // Get more response info...
     // const { statusCode, headers } = httpResponse;
     return {

--- a/standard-integration/server/php/composer.json
+++ b/standard-integration/server/php/composer.json
@@ -4,12 +4,15 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "paypal/paypal-server-sdk": "0.5.1"
+        "paypal/paypal-server-sdk": "0.6.0"
     },
     "require-dev": {
     },
     "scripts": {
-        "start": "php -S localhost:8080 -t src"
+        "start": [
+            "Composer\\Config::disableProcessTimeout",
+            "php -S localhost:8080 -t src"
+        ]
     },
     "config": {
     }

--- a/standard-integration/server/php/composer.lock
+++ b/standard-integration/server/php/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d4a57a266f3f33beef57b02efc8cfaac",
+    "content-hash": "f2e528a550aa0e8926b330dcdcfc67dc",
     "packages": [
         {
             "name": "apimatic/core",
@@ -224,16 +224,16 @@
         },
         {
             "name": "paypal/paypal-server-sdk",
-            "version": "0.5.1",
+            "version": "0.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/paypal/PayPal-PHP-Server-SDK.git",
-                "reference": "09148245f72f9dc2f6c8363b6206eac5effefa77"
+                "reference": "7d69e118998fdf2ae2cf234f1bd49f4248782380"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paypal/PayPal-PHP-Server-SDK/zipball/09148245f72f9dc2f6c8363b6206eac5effefa77",
-                "reference": "09148245f72f9dc2f6c8363b6206eac5effefa77",
+                "url": "https://api.github.com/repos/paypal/PayPal-PHP-Server-SDK/zipball/7d69e118998fdf2ae2cf234f1bd49f4248782380",
+                "reference": "7d69e118998fdf2ae2cf234f1bd49f4248782380",
                 "shasum": ""
             },
             "require": {
@@ -250,7 +250,7 @@
             "type": "library",
             "autoload": {
                 "psr-4": {
-                    "PaypalServerSDKLib\\": "src/"
+                    "PaypalServerSdkLib\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -261,9 +261,9 @@
             "homepage": "https://github.com/paypal/PayPal-PHP-Server-SDK",
             "support": {
                 "issues": "https://github.com/paypal/PayPal-PHP-Server-SDK/issues",
-                "source": "https://github.com/paypal/PayPal-PHP-Server-SDK/tree/0.5.1"
+                "source": "https://github.com/paypal/PayPal-PHP-Server-SDK/tree/0.6.0"
             },
-            "time": "2024-09-10T15:31:38+00:00"
+            "time": "2024-10-18T19:06:27+00:00"
         },
         {
             "name": "php-jsonpointer/php-jsonpointer",

--- a/standard-integration/server/php/src/index.php
+++ b/standard-integration/server/php/src/index.php
@@ -1,18 +1,18 @@
 <?php
 require __DIR__ . '/../vendor/autoload.php';
 
-use PaypalServerSDKLib\Authentication\ClientCredentialsAuthCredentialsBuilder;
-use PaypalServerSDKLib\Environment;
-use PaypalServerSDKLib\PaypalServerSDKClientBuilder;
-use PaypalServerSDKLib\Models\Builders\OrderRequestBuilder;
-use PaypalServerSDKLib\Models\CheckoutPaymentIntent;
-use PaypalServerSDKLib\Models\Builders\PurchaseUnitRequestBuilder;
-use PaypalServerSDKLib\Models\Builders\AmountWithBreakdownBuilder;
+use PaypalServerSdkLib\Authentication\ClientCredentialsAuthCredentialsBuilder;
+use PaypalServerSdkLib\Environment;
+use PaypalServerSdkLib\PaypalServerSdkClientBuilder;
+use PaypalServerSdkLib\Models\Builders\OrderRequestBuilder;
+use PaypalServerSdkLib\Models\CheckoutPaymentIntent;
+use PaypalServerSdkLib\Models\Builders\PurchaseUnitRequestBuilder;
+use PaypalServerSdkLib\Models\Builders\AmountWithBreakdownBuilder;
 
 $PAYPAL_CLIENT_ID = getenv('PAYPAL_CLIENT_ID');
 $PAYPAL_CLIENT_SECRET = getenv('PAYPAL_CLIENT_SECRET');
 
-$client = PaypalServerSDKClientBuilder::init()
+$client = PaypalServerSdkClientBuilder::init()
     ->clientCredentialsAuthCredentials(
         ClientCredentialsAuthCredentialsBuilder::init(
             $PAYPAL_CLIENT_ID,

--- a/standard-integration/server/python/requirements.txt
+++ b/standard-integration/server/python/requirements.txt
@@ -1,2 +1,2 @@
 Flask==3.0.3
-paypal-server-sdk==0.5.2
+paypal-server-sdk==0.6.0

--- a/standard-integration/server/python/server.py
+++ b/standard-integration/server/python/server.py
@@ -5,7 +5,7 @@ from flask import Flask, request
 from paypalserversdk.http.auth.o_auth_2 import ClientCredentialsAuthCredentials
 from paypalserversdk.logging.configuration.api_logging_configuration import LoggingConfiguration, \
     RequestLoggingConfiguration, ResponseLoggingConfiguration
-from paypalserversdk.paypalserversdk_client import PaypalserversdkClient
+from paypalserversdk.paypal_serversdk_client import PaypalServersdkClient
 from paypalserversdk.controllers.orders_controller import OrdersController
 from paypalserversdk.models.amount_with_breakdown import AmountWithBreakdown
 from paypalserversdk.models.checkout_payment_intent import CheckoutPaymentIntent
@@ -15,7 +15,7 @@ from paypalserversdk.api_helper import ApiHelper
 
 app = Flask(__name__)
 
-paypal_client: PaypalserversdkClient = PaypalserversdkClient(
+paypal_client: PaypalServersdkClient = PaypalServersdkClient(
     client_credentials_auth_credentials=ClientCredentialsAuthCredentials(
         o_auth_client_id=os.getenv('PAYPAL_CLIENT_ID'),
         o_auth_client_secret=os.getenv('PAYPAL_CLIENT_SECRET')

--- a/standard-integration/server/ruby/Gemfile
+++ b/standard-integration/server/ruby/Gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "paypal-server-sdk", "~> 0.5.2"
+gem "paypal-server-sdk", "~> 0.6.0"
 gem "puma", "~> 6.4"
 gem "rackup", "~> 2.1"
 gem "sinatra", "~> 4.0"


### PR DESCRIPTION
This PR bumps the SDKs for each language in both standard and advanced integrations to the most current released version.  This also resolves some namespace/class name changes as a result of that bump.

These namespace/class name changes were required to resolve issues with some languages on case-sensitive filesystems (such as ext4) which would cause cryptic error messages due to variants of  the `ClassNotFound` exception.  

No functionality is changed in this PR.