### PR TITLE
fix: provide proper camelCased fields for initialOptions in react

### DIFF
--- a/standard-integration/client/react/src/App.jsx
+++ b/standard-integration/client/react/src/App.jsx
@@ -8,9 +8,9 @@ function Message({ content }) {
 
 function App() {
   const initialOptions = {
-    "client-id": import.meta.env.PAYPAL_CLIENT_ID,
-    "enable-funding": "venmo",
-    "buyer-country": "US",
+    clientId: import.meta.env.PAYPAL_CLIENT_ID,
+    enableFunding: "venmo",
+    buyerCountry: "US",
     currency: "USD",
     components: "buttons",
   };


### PR DESCRIPTION
### Description
In current **simple-integration example** for react `initialOptions` are provided like in raw html example, but seems like this is not what Provider is accepting

